### PR TITLE
add a safety check for invalid request

### DIFF
--- a/endpoint.php
+++ b/endpoint.php
@@ -264,7 +264,7 @@ if ($method === 'GET') {
     }
     $me = filter_input_array(INPUT_GET, [
         'me' => FILTER_VALIDATE_URL,
-    ])
+    ]);
     if (!isset($me)) {
         invalidRequest();
     }

--- a/endpoint.php
+++ b/endpoint.php
@@ -262,6 +262,12 @@ if ($method === 'GET') {
         header('HTTP/1.1 200 OK');
         exit();
     }
+    $me = filter_input_array(INPUT_GET, [
+        'me' => FILTER_VALIDATE_URL,
+    ])
+    if (!isset($me)) {
+        invalidRequest();
+    }
     $request = array_merge(
         filter_input_array(INPUT_POST, [
             'grant_type' => [
@@ -275,9 +281,7 @@ if ($method === 'GET') {
             'client_id' => FILTER_VALIDATE_URL,
             'redirect_uri' => FILTER_VALIDATE_URL,
         ]),
-        filter_input_array(INPUT_GET, [
-            'me' => FILTER_VALIDATE_URL,
-        ])
+        $me
     );
     if (in_array(null, $request, true) || in_array(false, $request, true)) {
         invalidRequest();


### PR DESCRIPTION
IndieAuth\Client (https://github.com/indieweb/indieauth-client-php) does not send 'me' in the query parameters.

This change should more gracefully handle that issue.